### PR TITLE
fix short trial description

### DIFF
--- a/lib/Bio/Chado/Schema/Result/Phenotype/Phenotype.pm
+++ b/lib/Bio/Chado/Schema/Result/Phenotype/Phenotype.pm
@@ -104,15 +104,13 @@ __PACKAGE__->add_columns(
   "cvalue_id",
   { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
   "assay_id",
-
   { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
   "create_date",
   { data_type => "text", is_nullable => 0 },
-    { data_type => "integer", is_foreign_key => 1, is_nullable => 1 },
-    "collect_date",
-    { data_type => "text", is_nullable => 1 },
-    "operator",
-    { data_type => "text", is_nullable => 1 },
+  "collect_date",
+  { data_type => "text", is_nullable => 1 },
+  "operator",
+  { data_type => "text", is_nullable => 1 },
 );
 __PACKAGE__->set_primary_key("phenotype_id");
 __PACKAGE__->add_unique_constraint("phenotype_c1", ["uniquename"]);

--- a/lib/Bio/Chado/Schema/Result/Project/Project.pm
+++ b/lib/Bio/Chado/Schema/Result/Project/Project.pm
@@ -36,7 +36,7 @@ __PACKAGE__->table("project");
 
   data_type: 'varchar'
   is_nullable: 0
-  size: 255
+  # note size limit was removed, as it is a text field in the db
 
 =head2 create_date
 
@@ -69,7 +69,7 @@ __PACKAGE__->add_columns(
   "name",
   { data_type => "varchar", is_nullable => 0, size => 255 },
   "description",
-  { data_type => "varchar", is_nullable => 0, size => 255 },
+  { data_type => "varchar", is_nullable => 0 },
   "create_date",
   {
     data_type     => "timestamp",

--- a/lib/Bio/Chado/Schema/Result/Stock/Stockprop.pm
+++ b/lib/Bio/Chado/Schema/Result/Stock/Stockprop.pm
@@ -51,6 +51,12 @@ __PACKAGE__->table("stockprop");
   data_type: 'text'
   is_nullable: 1
 
+=head2 value_jsonb
+
+  data_type: 'text'
+  is_nullable: 1
+
+
 =head2 rank
 
   data_type: 'integer'
@@ -72,7 +78,9 @@ __PACKAGE__->add_columns(
   "type_id",
   { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
   "value",
-  { data_type => "text", is_nullable => 1 },
+    { data_type => "text", is_nullable => 1 },
+    "value_jsonb",
+    {data_type => "text", is_nullable => 1},
   "rank",
   { data_type => "integer", default_value => 0, is_nullable => 0 },
 );


### PR DESCRIPTION
The short trial description constraint comes from the DBIx::Class accessor, which limits it to 256 characters. (The database is a text field). This pull request removes that limitation.